### PR TITLE
Add publish flag for series 

### DIFF
--- a/timeseries-spi-impl/sos-series-dao/src/main/java/org/n52/series/api/v1/db/da/TimeseriesRepository.java
+++ b/timeseries-spi-impl/sos-series-dao/src/main/java/org/n52/series/api/v1/db/da/TimeseriesRepository.java
@@ -193,14 +193,16 @@ public class TimeseriesRepository extends SessionAwareRepository implements Outp
         Set<SeriesEntity> referenceValues = series.getReferenceValues();
         List<ReferenceValueOutput> outputs = new ArrayList<ReferenceValueOutput>();
         for (SeriesEntity referenceSeriesEntity : referenceValues) {
-            ReferenceValueOutput refenceValueOutput = new ReferenceValueOutput();
-            ProcedureEntity procedure = referenceSeriesEntity.getProcedure();
-            refenceValueOutput.setLabel(procedure.getNameI18n(query.getLocale()));
-            refenceValueOutput.setReferenceValueId(referenceSeriesEntity.getPkid().toString());
+            if (referenceSeriesEntity.isPublished()) {
+                ReferenceValueOutput refenceValueOutput = new ReferenceValueOutput();
+                ProcedureEntity procedure = referenceSeriesEntity.getProcedure();
+                refenceValueOutput.setLabel(procedure.getNameI18n(query.getLocale()));
+                refenceValueOutput.setReferenceValueId(referenceSeriesEntity.getPkid().toString());
 
-            ObservationEntity lastValue = series.getLastValue();
-            refenceValueOutput.setLastValue(createTimeseriesValueFor(lastValue, series));
-            outputs.add(refenceValueOutput);
+                ObservationEntity lastValue = series.getLastValue();
+                refenceValueOutput.setLastValue(createTimeseriesValueFor(lastValue, series));
+                outputs.add(refenceValueOutput);
+            }
         }
         return outputs.toArray(new ReferenceValueOutput[0]);
     }
@@ -237,11 +239,13 @@ public class TimeseriesRepository extends SessionAwareRepository implements Outp
                                                                 Session session) throws DataAccessException {
         Map<String, TimeseriesData> referenceSeries = new HashMap<String, TimeseriesData>();
         for (SeriesEntity referenceSeriesEntity : referenceValues) {
-            TimeseriesData referenceSeriesData = createTimeseriesData(referenceSeriesEntity, query, session);
-            if (haveToExpandReferenceData(referenceSeriesData)) {
-                referenceSeriesData = expandReferenceDataIfNecessary(referenceSeriesEntity, query, session);
+            if (referenceSeriesEntity.isPublished()) {
+                TimeseriesData referenceSeriesData = createTimeseriesData(referenceSeriesEntity, query, session);
+                if (haveToExpandReferenceData(referenceSeriesData)) {
+                    referenceSeriesData = expandReferenceDataIfNecessary(referenceSeriesEntity, query, session);
+                }
+                referenceSeries.put(referenceSeriesEntity.getPkid().toString(), referenceSeriesData);
             }
-            referenceSeries.put(referenceSeriesEntity.getPkid().toString(), referenceSeriesData);
         }
         return referenceSeries;
     }

--- a/timeseries-spi-impl/sos-series-dao/src/main/java/org/n52/series/api/v1/db/da/beans/ObservationEntity.java
+++ b/timeseries-spi-impl/sos-series-dao/src/main/java/org/n52/series/api/v1/db/da/beans/ObservationEntity.java
@@ -33,14 +33,14 @@ import java.util.Date;
 public class ObservationEntity {
 
     private Long pkid;
-    
+
     private Date timestamp;
-    
+
     private Double value;
-    
-    private long seriesPkid;
-    
-    private boolean deleted;
+
+    private Long seriesPkid;
+
+    private Boolean deleted;
 
     public Long getPkid() {
         return pkid;
@@ -65,7 +65,7 @@ public class ObservationEntity {
     public void setValue(Double value) {
         this.value = value;
     }
-    
+
     public Long getSeriesPkid() {
         return seriesPkid;
     }
@@ -78,10 +78,10 @@ public class ObservationEntity {
         return deleted;
     }
 
-    public void setDeleted(boolean deleted) {
+    public void setDeleted(Boolean deleted) {
         this.deleted = deleted;
     }
-    
+
     @Override
     public String toString() {
         StringBuilder sb = new StringBuilder();

--- a/timeseries-spi-impl/sos-series-dao/src/main/java/org/n52/series/api/v1/db/da/beans/SeriesEntity.java
+++ b/timeseries-spi-impl/sos-series-dao/src/main/java/org/n52/series/api/v1/db/da/beans/SeriesEntity.java
@@ -49,6 +49,8 @@ public class SeriesEntity {
 
     private UnitEntity unit;
 
+    private boolean published;
+
     private List<ObservationEntity> observations = new ArrayList<ObservationEntity>();
 
     private Set<SeriesEntity> referenceValues = new HashSet<SeriesEntity>();
@@ -129,11 +131,21 @@ public class SeriesEntity {
         this.unit = unit;
     }
 
+    public Boolean isPublished() {
+        return published;
+    }
+
+    public void setPublished(Boolean published) {
+        this.published = published;
+    }
+
     public ObservationEntity getFirstValue() {
-        Date when = firstValue.getTimestamp();
-        Double value = firstValue.getValue();
-        if (when == null || value == null) {
-            return null; // empty component
+        if (firstValue != null) {
+           Date when = firstValue.getTimestamp();
+            Double value = firstValue.getValue();
+            if (when == null || value == null) {
+                return null; // empty component
+            }
         }
         return firstValue;
     }
@@ -143,10 +155,12 @@ public class SeriesEntity {
     }
 
     public ObservationEntity getLastValue() {
-        Date when = lastValue.getTimestamp();
-        Double value = lastValue.getValue();
-        if (when == null || value == null) {
-            return null; // empty component
+        if (lastValue != null) {
+            Date when = lastValue.getTimestamp();
+            Double value = lastValue.getValue();
+            if (when == null || value == null) {
+                return null; // empty component
+            }
         }
         return lastValue;
     }

--- a/timeseries-spi-impl/sos-series-dao/src/main/java/org/n52/series/api/v1/db/da/dao/SeriesDao.java
+++ b/timeseries-spi-impl/sos-series-dao/src/main/java/org/n52/series/api/v1/db/da/dao/SeriesDao.java
@@ -54,34 +54,34 @@ public class SeriesDao extends AbstractDao<SeriesEntity> {
     public SeriesDao(Session session) {
         super(session);
     }
-    
+
     @Override
     @SuppressWarnings("unchecked")
     public List<SeriesEntity> find(String search, DbQuery query) {
 
-        /* 
-         * Timeseries labels are constructed from labels of related feature 
-         * and phenomenon. Therefore we have to join both tables and search 
+        /*
+         * Timeseries labels are constructed from labels of related feature
+         * and phenomenon. Therefore we have to join both tables and search
          * for given pattern on any of the stored labels.
          */
-        
+
         List<SeriesEntity> series = new ArrayList<SeriesEntity>();
-        Criteria criteria = session.createCriteria(SeriesEntity.class);
+        Criteria criteria = addIgnoreNonPublishedSeriesTo(session.createCriteria(SeriesEntity.class));
         Criteria featureCriteria = criteria.createCriteria("feature", LEFT_OUTER_JOIN);
         Criteria procedureCriteria = criteria.createCriteria("procedure", LEFT_OUTER_JOIN);
-        
+
         if (hasTranslation(query, I18nFeatureEntity.class)) {
             featureCriteria = query.addLocaleTo(featureCriteria, I18nFeatureEntity.class);
-        } 
+        }
         featureCriteria.add(Restrictions.ilike("name", "%" + search + "%"));
-        series.addAll(featureCriteria.list()); 
-        
+        series.addAll(featureCriteria.list());
+
         if (hasTranslation(query, I18nProcedureEntity.class)) {
             procedureCriteria = query.addLocaleTo(procedureCriteria, I18nProcedureEntity.class);
         }
         procedureCriteria.add(Restrictions.ilike("name", "%" + search + "%"));
         series.addAll(procedureCriteria.list());
-        
+
         return series;
     }
 
@@ -92,7 +92,11 @@ public class SeriesDao extends AbstractDao<SeriesEntity> {
 
     @Override
     public SeriesEntity getInstance(Long key, DbQuery parameters) throws DataAccessException {
-        return (SeriesEntity) session.get(SeriesEntity.class, key);
+        Criteria criteria = session.createCriteria(SeriesEntity.class)
+                .add(eq("pkid", key));
+        addIgnoreNonPublishedSeriesTo(criteria);
+        return (SeriesEntity) criteria.uniqueResult();
+        //return (SeriesEntity) session.get(SeriesEntity.class, key);
     }
 
     @Override
@@ -103,10 +107,11 @@ public class SeriesDao extends AbstractDao<SeriesEntity> {
     @Override
     @SuppressWarnings("unchecked")
     public List<SeriesEntity> getAllInstances(DbQuery parameters) throws DataAccessException {
-        Criteria criteria = session.createCriteria(SeriesEntity.class, "s")
-                .createCriteria("procedure")
+        Criteria criteria = session.createCriteria(SeriesEntity.class, "s");
+        addIgnoreNonPublishedSeriesTo(criteria, "s");
+        criteria.createCriteria("procedure")
                 .add(eq("reference", false));
-        
+
         DetachedCriteria filter = parameters.createDetachedFilterCriteria("pkid");
         criteria.add(Subqueries.propertyIn("s.pkid", filter));
 
@@ -128,6 +133,20 @@ public class SeriesDao extends AbstractDao<SeriesEntity> {
                 .createCriteria(SeriesEntity.class)
                 .setProjection(Projections.rowCount());
         return criteria != null ? ((Long) criteria.uniqueResult()).intValue() : 0;
+    }
+
+    private Criteria addIgnoreNonPublishedSeriesTo(Criteria criteria) {
+        return addIgnoreNonPublishedSeriesTo(criteria, null);
+    }
+
+    private Criteria addIgnoreNonPublishedSeriesTo(Criteria criteria, String alias) {
+        alias = alias == null ? "" : alias + ".";
+        criteria.add(Restrictions.and(
+                Restrictions.and(
+                        Restrictions.isNotNull(alias + "firstValue"),
+                        Restrictions.isNotNull(alias + "lastValue")),
+                Restrictions.eq(alias + "published", true)));
+        return criteria;
     }
 
 }

--- a/timeseries-spi-impl/sos-series-dao/src/main/resources/hbm/sos/series/SeriesResource.hbm.xml
+++ b/timeseries-spi-impl/sos-series-dao/src/main/resources/hbm/sos/series/SeriesResource.hbm.xml
@@ -13,13 +13,15 @@
         <many-to-one name="unit" class="org.n52.series.api.v1.db.da.beans.UnitEntity" column="unitid" />
 	    <!-- defines a fixed number of decimal places -->
         <property name="numberOfDecimals" formula="3" type="int" />
+
+        <!-- TODO remove formula when SOS adds published_flag to data model -->
+        <property name="published" column="published_flag" formula="1" type="org.hibernate.type.NumericBooleanType" />
+
         <component name="firstValue" class="org.n52.series.api.v1.db.da.beans.ObservationEntity">
-	        <property name="seriesPkid" column="seriesid"  type="long" insert="false" update="false"/>
 	        <property name="timestamp" column="firsttimestamp" type="timestamp" />
 	        <property name="value" column="firstnumericvalue" type="double" />
         </component>
         <component name="lastValue" class="org.n52.series.api.v1.db.da.beans.ObservationEntity">
-            <property name="seriesPkid" column="seriesid"  type="long" insert="false" update="false"/>
             <property name="timestamp" column="lasttimestamp" type="timestamp" />
             <property name="value" column="lastnumericvalue" type="double" />
         </component>


### PR DESCRIPTION
Adding capability to mark series entities as published or not published. In addition a further criterion has been added to ignore series entities which have not set the first/last values of a timeseries (assuming that there are no observations yet)